### PR TITLE
Refactor on startup configuration, sqlalchemy session maker, and email sender factory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,7 @@ venv.bak/
 
 # Rope project settings
 .ropeproject
+.vscode
 
 # mkdocs documentation
 /site

--- a/src/labs/db.py
+++ b/src/labs/db.py
@@ -6,10 +6,11 @@
 
 """
 
+from typing import AsyncGenerator
 from sqlalchemy.ext.asyncio import create_async_engine,\
-    AsyncSession
+    AsyncSession, async_sessionmaker, AsyncAttrs
 from sqlalchemy.orm import DeclarativeBase,\
-    configure_mappers, sessionmaker
+    configure_mappers
 
 
 from .settings import settings
@@ -24,19 +25,16 @@ engine = create_async_engine(
 configure_mappers()
 
 # Get an async session from the engine
+AsyncSessionFactory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
 
-async def get_async_session() -> AsyncSession:
-    async_session = sessionmaker(
-        engine, class_=AsyncSession, expire_on_commit=False
-    )
-    async with async_session() as session:
+async def get_async_session() -> AsyncGenerator[AsyncSession, None]:
+    async with AsyncSessionFactory() as session:
         yield session
 
+
 # Used by the ORM layer to describe models
-
-
-class Base(DeclarativeBase):
+class Base(DeclarativeBase, AsyncAttrs):
     """
     SQLAlchemy 2.0 style declarative base class
     https://bit.ly/3WE3Srg

--- a/src/labs/email.py
+++ b/src/labs/email.py
@@ -14,11 +14,22 @@ reference the configuration and can simply provide the template information
 Redmail docs are located at https://red-mail.readthedocs.io/
 """
 import os
-from redmail import EmailSender
+from redmail.email.sender import EmailSender
 
 from .settings import settings
 
-sender = EmailSender(
+# Custom factory to be able to set the sender globally
+class EmailSenderFactory(EmailSender):
+    @property
+    def sender(self):
+        return self.sender
+    
+    @sender.setter
+    def sender(self, sender: str):
+        self.sender = sender
+
+
+sender = EmailSenderFactory(
     host=settings.smtp.host,
     port=settings.smtp.port,
     username=settings.smtp.user.get_secret_value(),


### PR DESCRIPTION
There are 3 refactors that happens to this PR:
- change session maker to use `async_sessionmaker` instead of `sessionmaker`
```python
# async_sessionmaker import from sqlalchemy.ext.asyncio
AsyncSessionFactory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)

async def get_async_session() -> AsyncGenerator[AsyncSession, None]:
    async with AsyncSessionFactory() as session:
        yield session
```
- Fastapi doesn't provide `on_event` now to setup lifespan event. But It can be setup directly to fastapi instance as lifespan attributes. Just create context manager generator to setup lifespan event. Ref: https://fastapi.tiangolo.com/advanced/events/
```python
@asynccontextmanager
async def lifespan(_fastapi: FastAPI):
    if broker.is_worker_process:
        # TaskIQ configurartion so we can share FastAPI dependencies in tasks
        await broker.startup()
    
    yield

    if broker.is_worker_process:
        # On shutdown, we need to shutdown the broker
        await broker.shutdown()
```
- The last is provide custom factory to enable setter for sender globally
```python
# Custom factory to be able to set the sender globally
class EmailSenderFactory(EmailSender):
    @property
    def sender(self):
        return self.sender
    
    @sender.setter
    def sender(self, sender: str):
        self.sender = sender
```