### PR TITLE
fix: prevent `maximum recursion depth exceeded` in EmailSenderFactory.sender property

### DIFF
--- a/src/labs/email.py
+++ b/src/labs/email.py
@@ -22,11 +22,11 @@ from .settings import settings
 class EmailSenderFactory(EmailSender):
     @property
     def sender(self):
-        return self.sender
+        return self._sender
     
     @sender.setter
     def sender(self, sender: str):
-        self.sender = sender
+        self._sender = sender
 
 
 sender = EmailSenderFactory(


### PR DESCRIPTION
```python
Traceback (most recent call last):
 ....
    self.sender = sender
    ^^^^^^^^^^^
  [Previous line repeated 995 more times]
RecursionError: maximum recursion depth exceeded

```